### PR TITLE
Missing argument fixed

### DIFF
--- a/bindings/pydeck/pydeck/bindings/deck.py
+++ b/bindings/pydeck/pydeck/bindings/deck.py
@@ -9,13 +9,14 @@ from .view import View
 from .view_state import ViewState
 from .base_map_provider import BaseMapProvider
 from .map_styles import DARK, get_from_map_identifier
+from ipywidgets import DOMWidget
 
 
 def has_jupyter_extra():
     try:
         from ..widget import DeckGLWidget
 
-        DeckGLWidget()
+        DeckGLWidget(DOMWidget)
         return True
     except (ImportError, NotImplementedError):
         return False


### PR DESCRIPTION
Trying example on https://docs.streamlit.io/library/api-reference/charts/st.pydeck_chart and got this error :

TypeError: wrap() missing 1 required positional argument: 'widget'
